### PR TITLE
Async the getUser function

### DIFF
--- a/final/index.js
+++ b/final/index.js
@@ -26,11 +26,11 @@ app.use(helmet());
 app.use(cors());
 
 // get the user info from a JWT
-const getUser = token => {
+const getUser = async (token) => {
   if (token) {
     try {
       // return the user information from the token
-      return jwt.verify(token, process.env.JWT_SECRET);
+      return await jwt.verify(token, process.env.JWT_SECRET);
     } catch (err) {
       // if there's a problem with the token, throw an error
       throw new Error('Session invalid');
@@ -48,10 +48,10 @@ const server = new ApolloServer({
     // get the user token from the headers
     const token = req.headers.authorization;
     // try to retrieve a user with the token
-    const user = getUser(token);
+    const user = await getUser(token);
     // add the db models and the user to the context
     return { models, user };
-  }
+  },
 });
 
 // Apply the Apollo GraphQL middleware and set the path to /api


### PR DESCRIPTION
Making the "getUser" function asynchronous.

In Chapter 7. User Accounts and Authentication, page 58, we see "jwt.verify" function is used asynchronously.

![image](https://user-images.githubusercontent.com/3517218/97302057-7f4ddb00-1893-11eb-8305-3ddafd71620c.png)

In Chapter 9. Details, page 88, we see "getUser" is also used asynchronously during new ApolloServer initialization.

![image](https://user-images.githubusercontent.com/3517218/97302154-a3a9b780-1893-11eb-8c08-29a77e5ffef7.png)

